### PR TITLE
ProcessNewBlock: avoid crash when rejecting a forked chain

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4544,9 +4544,9 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDis
             mapBlockSource[pindex->GetBlockHash ()] = pfrom->GetId ();
         }
         CheckBlockIndex ();
-	    if (!ret) {
+        if (!ret) {
             // Check spamming
-            if(pfrom && GetBoolArg("-blockspamfilter", DEFAULT_BLOCK_SPAM_FILTER)) {
+            if(pindex && pfrom && GetBoolArg("-blockspamfilter", DEFAULT_BLOCK_SPAM_FILTER)) {
                 CNodeState *nodestate = State(pfrom->GetId());
 	        nodestate->nodeBlocks.onBlockReceived(pindex->nHeight);
                 bool nodeStatus = true;


### PR DESCRIPTION
pindex is deref'd without checking whether AcceptBlock completed or not, leading to a crash:

`ERROR: ContextualCheckBlockHeader: forked chain older than max reorganization depth (height 7941)
Segmentation fault (core dumped)`

This patch adds a check if pindex is set and simply falls to the existing error return if unset. 